### PR TITLE
Fixes typos in class names and bundle name

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,4 +1,4 @@
 pugx_botinfrastructure:
-    resource: "@PUGXBotinfrastructureBundle/Resources/config/routing.xml"
+    resource: "@PUGXBotInfrastructureBundle/Resources/config/routing.xml"
     prefix:   /
 

--- a/src/Infrastructure/Bundle/Controller/DefaultController.php
+++ b/src/Infrastructure/Bundle/Controller/DefaultController.php
@@ -8,6 +8,6 @@ class DefaultController extends Controller
 {
     public function indexAction($name)
     {
-        return $this->render('PUGXBotinfrastructureBundle:Default:index.html.twig', array('name' => $name));
+        return $this->render('PUGXBotInfrastructureBundle:Default:index.html.twig', array('name' => $name));
     }
 }

--- a/src/Infrastructure/Bundle/DependencyInjection/PUGXBotInfrastructureExtension.php
+++ b/src/Infrastructure/Bundle/DependencyInjection/PUGXBotInfrastructureExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Loader;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class PUGXBotinfrastructureExtension extends Extension
+class PUGXBotInfrastructureExtension extends Extension
 {
     /**
      * {@inheritDoc}

--- a/src/Infrastructure/Bundle/Resources/config/routing.xml
+++ b/src/Infrastructure/Bundle/Resources/config/routing.xml
@@ -5,6 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="pugx_botinfrastructure_homepage" path="/hello/{name}">
-        <default key="_controller">PUGXBotinfrastructureBundle:Default:index</default>
+        <default key="_controller">PUGXBotInfrastructureBundle:Default:index</default>
     </route>
 </routes>


### PR DESCRIPTION
Those typos generate errors while cleaning cache 
`Case mismatch between loaded and declared class names`

and make a (useless) test fails because of the wrong routing configuration
